### PR TITLE
Add support for meshes with textures

### DIFF
--- a/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
@@ -124,6 +124,7 @@ private:
   rendering::RenderEngine * engine;
   rendering::ScenePtr scene;
   bool dirty;
+  bool initialized;
   bool populated;
   QColor color;
 };

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/RobotModelDisplay.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/RobotModelDisplay.hpp
@@ -291,6 +291,7 @@ private:
   bool destroyModel;
   bool showVisual;
   bool showCollision;
+  bool dirty;
   float alpha;
   QStandardItem * parentRow;
 };

--- a/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
@@ -33,7 +33,7 @@ namespace plugins
 {
 ////////////////////////////////////////////////////////////////////////////////
 GlobalOptions::GlobalOptions()
-: dirty(false), populated(false)
+: dirty(false), initialized(false), populated(false), color("#303030")
 {
   // TODO(Sarathkrishnan Ramesh)
   // Add support to select render engine using config file
@@ -77,11 +77,22 @@ bool GlobalOptions::eventFilter(QObject * _object, QEvent * _event)
 {
   if (_event->type() == gui::events::Render::kType) {
     std::lock_guard(this->lock);
-    // Update background color
-    if (dirty) {
+    if (!initialized) {
       if (this->scene == nullptr) {
         this->scene = this->engine->SceneByName("scene");
+
+        // Configure scene lighting
+        this->scene->SetAmbientLight(0.5, 0.5, 0.5);
+        auto light = this->scene->CreatePointLight();
+        light->SetDiffuseColor(0.8, 0.8, 0.8);
+        light->SetSpecularColor(0.8, 0.8, 0.8);
+        light->SetLocalPosition(0, 0, 8);
+        this->scene->RootVisual()->AddChild(light);
       }
+    }
+
+    // Update background color
+    if (dirty) {
       this->scene->SetBackgroundColor(math::Color(color.redF(), color.greenF(), color.blue()));
       this->dirty = false;
     }

--- a/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
@@ -82,12 +82,13 @@ bool GlobalOptions::eventFilter(QObject * _object, QEvent * _event)
         this->scene = this->engine->SceneByName("scene");
 
         // Configure scene lighting
-        this->scene->SetAmbientLight(0.5, 0.5, 0.5);
         auto light = this->scene->CreatePointLight();
         light->SetDiffuseColor(0.8, 0.8, 0.8);
         light->SetSpecularColor(0.8, 0.8, 0.8);
         light->SetLocalPosition(0, 0, 8);
         this->scene->RootVisual()->AddChild(light);
+
+        initialized = true;
       }
     }
 

--- a/ign_rviz_plugins/src/rviz/plugins/RobotModelDisplay.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/RobotModelDisplay.cpp
@@ -314,15 +314,25 @@ void RobotModelDisplay::createLink(const urdf::Link * _link)
     robotLink.visual = createLinkGeometry(_link->visual->geometry);
     if (robotLink.visual != nullptr) {
       if (_link->visual->material == nullptr) {
-        // Use default material
-        const auto & mat = this->scene->Material("RobotModel/Red");
-        // Update alpha
-        auto color = mat->Ambient();
-        color.A(this->alpha);
-        mat->SetAmbient(color);
-        mat->SetDiffuse(color);
-        mat->SetEmissive(color);
-        robotLink.visual->SetMaterial(mat);
+        // Set default material only if the visual mesh doeesn't have textures
+        bool meshWithTexture = false;
+        const auto meshInfo = std::dynamic_pointer_cast<urdf::Mesh>(_link->visual->geometry);
+        if (meshInfo != nullptr) {
+          const auto fileExtension = meshInfo->filename.substr(meshInfo->filename.size() - 4);
+          meshWithTexture = (fileExtension == ".dae" || fileExtension == ".obj");
+        }
+
+        if (!meshWithTexture) {
+          // Use default material
+          const auto & mat = this->scene->Material("RobotModel/Red");
+          // Update alpha
+          auto color = mat->Ambient();
+          color.A(this->alpha);
+          mat->SetAmbient(color);
+          mat->SetDiffuse(color);
+          mat->SetEmissive(color);
+          robotLink.visual->SetMaterial(mat);
+        }
       } else if (!_link->visual->material_name.empty()) {
         // Use registered material
         const auto & mat = this->scene->Material(_link->visual->material_name);


### PR DESCRIPTION
This will add support for dae (collada) and obj mesh files with related texture information. Currently, I was adding the default material for all mesh visual. The mesh loader provided by ignition does load the related textures as well, so added checks for dae and obj files.

**Spot: Collada**

<img src="https://user-images.githubusercontent.com/33201532/94961055-935f2080-0511-11eb-999d-9a5fa0e4414f.gif" height=300/>

**Prius: Obj**

<img src="https://user-images.githubusercontent.com/33201532/94961072-9bb75b80-0511-11eb-80cb-c07850ad44b9.png" height="301"/>

**PR2: Collada and stl**

<img src="https://user-images.githubusercontent.com/33201532/94975517-96690980-052f-11eb-89d6-0dfdfd21a670.png" height="301"/>







Signed-off-by: Sarathkrishnan Ramesh <sarathkrishnan99@gmail.com>