### PR TITLE
Add depth and thermal camera support 

### DIFF
--- a/ign_rviz_plugins/include/ignition/rviz/plugins/ImageDisplay.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/ImageDisplay.hpp
@@ -173,6 +173,9 @@ private:
   // Handle image with mono8 encoding
   void updateFromMONO8();
 
+  // Handle image with mono16 encoding
+  void updateFromMONO16();
+
   // Handle image with float32 encoding
   void updateFromFloat32();
 

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/ImageDisplay.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/ImageDisplay.hpp
@@ -173,6 +173,9 @@ private:
   // Handle image with mono8 encoding
   void updateFromMONO8();
 
+  // Handle image with float32 encoding
+  void updateFromFloat32();
+
 public:
   ImageProvider * provider{nullptr};
 

--- a/ign_rviz_plugins/src/rviz/plugins/ImageDisplay.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/ImageDisplay.cpp
@@ -90,6 +90,8 @@ void ImageDisplay::callback(const sensor_msgs::msg::Image::SharedPtr _msg)
     updateFromRGB8();
   } else if (_msg->encoding == "mono8") {
     updateFromMONO8();
+  } else if (_msg->encoding == "32FC1") {
+    updateFromFloat32();
   } else {
     RCLCPP_ERROR(
       this->node->get_logger(), "Unsupported image encoding: %s",
@@ -114,11 +116,51 @@ void ImageDisplay::updateFromRGB8()
   this->newImage();
 }
 
+////////////////////////////////////////////////////////////////////////////////
 void ImageDisplay::updateFromMONO8()
 {
   QImage image(&msg->data[0], msg->width, msg->height, msg->step, QImage::Format_Grayscale8);
   this->provider->SetImage(image);
   this->newImage();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void ImageDisplay::updateFromFloat32()
+{
+  unsigned int height = msg->height;
+  unsigned int width = msg->width;
+
+  QImage image = QImage(width, height, QImage::Format_RGB888);
+
+  unsigned int depthSamples = width * height;
+
+  unsigned int depthBufferSize = depthSamples * sizeof(float);
+
+  float * depthBuffer = new float[depthSamples];
+
+  memcpy(depthBuffer, &msg->data[0], depthBufferSize);
+
+  float maxDepth = 0;
+  for (unsigned int i = 0; i < depthSamples; ++i) {
+    if (depthBuffer[i] > maxDepth && !std::isinf(depthBuffer[i])) {
+      maxDepth = depthBuffer[i];
+    }
+  }
+  unsigned int idx = 0;
+  double factor = 255 / maxDepth;
+  for (unsigned int j = 0; j < height; ++j) {
+    for (unsigned int i = 0; i < width; ++i) {
+      float d = depthBuffer[idx++];
+      d = 255 - (d * factor);
+      QRgb value = qRgb(d, d, d);
+      image.setPixel(i, j, value);
+    }
+  }
+
+  this->provider->SetImage(image);
+  this->newImage();
+
+  delete[] depthBuffer;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Render depth image received with float32 (32FC1) encoding and thermal image received with mono16 encoding.

![Screenshot from 2020-10-04 17-41-28](https://user-images.githubusercontent.com/33201532/95015594-66268580-066b-11eb-9945-fa832ed71223.png)


Signed-off-by: Sarathkrishnan Ramesh <sarathkrishnan99@gmail.com>