### PR TITLE
Remove dock and close button from title bar of Global Options plugin

### DIFF
--- a/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
@@ -158,6 +158,10 @@ void GlobalOptions::LoadConfig(const tinyxml2::XMLElement * /*_pluginElem*/)
   if (this->title.empty()) {
     this->title = "Global Options";
   }
+
+  auto cardItem = this->CardItem();
+  cardItem->setProperty("showCloseButton", false);
+  cardItem->setProperty("showDockButton", false);
 }
 
 }  // namespace plugins


### PR DESCRIPTION
This is a minor yet important fix, I believe. Removed the dock and close button from the title bar of the Global Options plugin because I have accidentally closed the plugin when trying to collapse/expand it. There is no other way to bring back the Global Options plugin after closing it during runtime.

Signed-off-by: Sarathkrishnan Ramesh <sarathkrishnan99@gmail.com>