### PR TITLE
Remove tf subscription from frame manager and use tf buffer instead

### DIFF
--- a/ign_rviz_common/include/ignition/rviz/common/frame_manager.hpp
+++ b/ign_rviz_common/include/ignition/rviz/common/frame_manager.hpp
@@ -90,23 +90,12 @@ public:
    */
   std::string getFixedFrame();
 
-protected:
-  /**
-   * @brief Callback function to received transform messages
-   * @param[in] _msg: Transform message
-   */
-  void tf_callback(const tf2_msgs::msg::TFMessage::SharedPtr _msg);
-
 private:
   rclcpp::Node::SharedPtr node;
   std::mutex tf_mutex_;
   std::string fixedFrame;
   std::shared_ptr<tf2_ros::Buffer> tfBuffer;
   std::shared_ptr<tf2_ros::TransformListener> tfListener;
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr subscriber;
-  std::unordered_map<std::string, ignition::math::Pose3d> tfTree;
-  tf2::TimePoint timePoint;
-  unsigned int frameCount;
 };
 }  // namespace common
 }  // namespace rviz

--- a/ign_rviz_common/include/ignition/rviz/common/frame_manager.hpp
+++ b/ign_rviz_common/include/ignition/rviz/common/frame_manager.hpp
@@ -80,9 +80,9 @@ public:
 
   /**
    * @brief Get available tf frames
-   * @param[out] _frames: List of available frames
+   * @return List of available frames
    */
-  void getFrames(std::vector<std::string> & _frames);
+  std::vector<std::string> getFrames();
 
   /**
    *  @brief Get fixed frame

--- a/ign_rviz_common/include/ignition/rviz/common/rviz_events.hpp
+++ b/ign_rviz_common/include/ignition/rviz/common/rviz_events.hpp
@@ -45,19 +45,6 @@ public:
   static const QEvent::Type kType = QEvent::Type(startingEventId);
 };
 
-/**
- * @brief Event is generated when the frame list is changed
- */
-class FrameListChanged : public QEvent
-{
-public:
-  FrameListChanged()
-  : QEvent(kType)
-  {}
-  /// \brief Unique type for this event.
-  static const QEvent::Type kType = QEvent::Type(startingEventId + 1);
-};
-
 }  // namespace events
 }  // namespace rviz
 }  // namespace ignition

--- a/ign_rviz_common/src/rviz/common/frame_manager.cpp
+++ b/ign_rviz_common/src/rviz/common/frame_manager.cpp
@@ -63,10 +63,9 @@ std::string FrameManager::getFixedFrame()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void FrameManager::getFrames(std::vector<std::string> & _frames)
+std::vector<std::string> FrameManager::getFrames()
 {
-  std::lock_guard<std::mutex>(this->tf_mutex_);
-  _frames = tfBuffer->getAllFrameNames();
+  return tfBuffer->getAllFrameNames();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ign_rviz_common/src/rviz/common/frame_manager.cpp
+++ b/ign_rviz_common/src/rviz/common/frame_manager.cpp
@@ -59,7 +59,6 @@ void FrameManager::setFixedFrame(const std::string & _fixedFrame)
 ////////////////////////////////////////////////////////////////////////////////
 std::string FrameManager::getFixedFrame()
 {
-  std::lock_guard<std::mutex>(this->tf_mutex_);
   return this->fixedFrame;
 }
 
@@ -73,8 +72,6 @@ void FrameManager::getFrames(std::vector<std::string> & _frames)
 ////////////////////////////////////////////////////////////////////////////////
 bool FrameManager::getFramePose(const std::string & _frame, ignition::math::Pose3d & _pose)
 {
-  std::lock_guard<std::mutex>(this->tf_mutex_);
-
   if (this->fixedFrame.empty()) {
     RCLCPP_ERROR(this->node->get_logger(), "No fixed frame specified");
     return false;
@@ -106,8 +103,6 @@ bool FrameManager::getFramePose(const std::string & _frame, ignition::math::Pose
 ////////////////////////////////////////////////////////////////////////////////
 bool FrameManager::getParentPose(const std::string & _child, ignition::math::Pose3d & _pose)
 {
-  std::lock_guard<std::mutex>(this->tf_mutex_);
-
   std::string parent;
   // TODO(shrijitsingh99): The _getParent() API is only present for backwards compatability,
   // use some alternative method instead

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/AxesDisplay.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/AxesDisplay.hpp
@@ -104,7 +104,7 @@ public slots:
   /**
    * @brief Callback when refresh button is pressed.
    */
-  void onRefresh();
+  void refresh();
 
 private:
   void setScale();

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
@@ -116,7 +116,7 @@ public slots:
   /**
    * @brief Callback when refresh button is pressed.
    */
-  void onRefresh();
+  void refresh();
 
 private:
   std::mutex lock;

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/TFDisplay.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/TFDisplay.hpp
@@ -188,6 +188,7 @@ protected:
    */
   rendering::VisualPtr createVisualFrame();
 
+public slots:
   /**
    * @brief Update tree view and local frame list
    */

--- a/ign_rviz_plugins/res/qml/AxesDisplay.qml
+++ b/ign_rviz_plugins/res/qml/AxesDisplay.qml
@@ -35,7 +35,7 @@ Item {
         text: "\u21bb"
         Material.background: Material.primary
         onClicked: {
-          AxesDisplay.onRefresh();
+          AxesDisplay.refresh();
         }
       }
 
@@ -50,6 +50,13 @@ Item {
             return;
 
           AxesDisplay.setFrame(textAt(currentIndex));
+        }
+
+        Connections {
+          target: combo.popup
+          onAboutToShow: {
+            AxesDisplay.refresh();
+          }
         }
       }
     }

--- a/ign_rviz_plugins/res/qml/GlobalOptions.qml
+++ b/ign_rviz_plugins/res/qml/GlobalOptions.qml
@@ -36,7 +36,7 @@ Item {
         text: "\u21bb"
         Material.background: Material.primary
         onClicked: {
-          GlobalOptions.onRefresh();
+          GlobalOptions.refresh();
         }
       }
 
@@ -54,6 +54,13 @@ Item {
           }
 
           GlobalOptions.setFrame(textAt(currentIndex));
+        }
+
+        Connections {
+          target: combo.popup
+          onAboutToShow: {
+            GlobalOptions.refresh();
+          }
         }
 
         Connections {

--- a/ign_rviz_plugins/res/qml/TFDisplay.qml
+++ b/ign_rviz_plugins/res/qml/TFDisplay.qml
@@ -146,6 +146,7 @@ Item {
         text: model.name
         checked: model.checked
         onClicked: {
+          TFDisplay.refresh();
           model.checked = checked;
           TFDisplay.setFrameVisibility(model.name, model.checked);
         }

--- a/ign_rviz_plugins/src/rviz/plugins/AxesDisplay.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/AxesDisplay.cpp
@@ -87,9 +87,9 @@ bool AxesDisplay::eventFilter(QObject * object, QEvent * event)
   }
 
   // Update combo-box on frame list change
-  if (event->type() == rviz::events::FrameListChanged::kType) {
-    this->onRefresh();
-  }
+  // if (event->type() == rviz::events::FrameListChanged::kType) {
+  // this->onRefresh();
+  // }
 
   return QObject::eventFilter(object, event);
 }
@@ -148,7 +148,7 @@ void AxesDisplay::setFrameManager(std::shared_ptr<common::FrameManager> _frameMa
   this->frame = this->frameManager->getFixedFrame();
 
   // Update frame list
-  this->onRefresh();
+  this->refresh();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -158,14 +158,13 @@ QStringList AxesDisplay::getFrameList() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void AxesDisplay::onRefresh()
+void AxesDisplay::refresh()
 {
   // Clear
   this->frameList.clear();
 
   // Get updated list
-  std::vector<std::string> allFrames;
-  this->frameManager->getFrames(allFrames);
+  std::vector<std::string> allFrames = this->frameManager->getFrames();
   std::sort(allFrames.begin(), allFrames.end());
 
   this->frameList.push_back(QString::fromStdString("<Fixed Frame>"));

--- a/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
@@ -69,7 +69,7 @@ void GlobalOptions::setFrameManager(std::shared_ptr<common::FrameManager> _frame
   this->frameList.clear();
 
   // Update frame list
-  this->onRefresh();
+  this->refresh();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -99,11 +99,6 @@ bool GlobalOptions::eventFilter(QObject * _object, QEvent * _event)
     }
   }
 
-  // Update combo-box on frame list change
-  if (_event->type() == rviz::events::FrameListChanged::kType) {
-    this->onRefresh();
-  }
-
   return QObject::eventFilter(_object, _event);
 }
 
@@ -121,11 +116,10 @@ QStringList GlobalOptions::getFrameList() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void GlobalOptions::onRefresh()
+void GlobalOptions::refresh()
 {
   // Get updated list
-  std::vector<std::string> allFrames;
-  this->frameManager->getFrames(allFrames);
+  std::vector<std::string> allFrames = this->frameManager->getFrames();
 
   if (allFrames.size() != 0) {
     // Clear

--- a/ign_rviz_plugins/src/rviz/plugins/TFDisplay.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/TFDisplay.cpp
@@ -209,11 +209,6 @@ bool TFDisplay::eventFilter(QObject * _object, QEvent * _event)
     update();
   }
 
-  if (_event->type() == rviz::events::FrameListChanged::kType) {
-    // Refresh Tree View
-    this->refresh();
-  }
-
   return QObject::eventFilter(_object, _event);
 }
 
@@ -309,11 +304,10 @@ void TFDisplay::refresh()
 {
   std::lock_guard<std::mutex>(this->lock);
 
-  std::vector<std::string> frames;
-  this->frameManager->getFrames(frames);
+  std::vector<std::string> allFrames = this->frameManager->getFrames();
 
-  if (frames.size() > 0) {
-    for (const auto frame : frames) {
+  if (allFrames.size() > 0) {
+    for (const auto frame : allFrames) {
       this->frameInfo.insert({frame, true});
     }
 


### PR DESCRIPTION
**Summary**
1. Removes subscription of tf since buffer already does that internally
2. Since now there is no way to generate an event on an update of tf frames, therefore fetch the latest frames from the frame manager when and where it is needed and not rely on events to automatically update the frames.
3. Remove locks from frame manager as all the functions are mutually exclusive and tf buffer itself is thread-safe.