### PR TITLE
Update getFramePose from FrameManager

### DIFF
--- a/ign_rviz_common/src/rviz/common/frame_manager.cpp
+++ b/ign_rviz_common/src/rviz/common/frame_manager.cpp
@@ -144,6 +144,10 @@ bool FrameManager::getFramePose(const std::string & _frame, ignition::math::Pose
 
   _pose = math::Pose3d::Zero;
 
+  if(this->fixedFrame == _frame) {
+    return true;
+  }
+
   auto it = this->tfTree.find(_frame);
   if (it != tfTree.end()) {
     _pose = it->second;

--- a/ign_rviz_common/src/rviz/common/frame_manager.cpp
+++ b/ign_rviz_common/src/rviz/common/frame_manager.cpp
@@ -144,7 +144,7 @@ bool FrameManager::getFramePose(const std::string & _frame, ignition::math::Pose
 
   _pose = math::Pose3d::Zero;
 
-  if(this->fixedFrame == _frame) {
+  if (this->fixedFrame == _frame) {
     return true;
   }
 


### PR DESCRIPTION
Summary:
1. Update getFramePose from FrameManager to handle matching `Fixed Frame` and message frames in the absence of tf data.
2. This allows the plugins to show visualization if and only if the `Fixed Frame` and message frame match.
3. This change replicates the behavior of RViz2 to handle missing tf frames.


Future Plan:
- Show a warning for no tf data.
![tf_warn](https://user-images.githubusercontent.com/39728574/99261150-542b2b80-2842-11eb-9357-c1a05f3b7ad8.png)