### PR TITLE
Add FixedFrame tf status in GlobalOptions

### DIFF
--- a/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
@@ -40,7 +40,7 @@ namespace plugins
 {
 /**
  * @brief TF status and message
- * 
+ *
  * Displays tf status and message under GlobalOptions
  */
 class TFStatus : public QObject

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
@@ -24,6 +24,7 @@
 #include <ignition/math/Color.hh>
 #include <QColor>
 #include <string>
+#include <vector>
 #include <memory>
 #include <utility>
 
@@ -37,6 +38,100 @@ namespace rviz
 {
 namespace plugins
 {
+/**
+ * @brief TF status and message
+ * 
+ * Displays tf status and message under GlobalOptions
+ */
+class TFStatus : public QObject
+{
+  Q_OBJECT
+
+  /**
+   *  @brief TF status
+   */
+  Q_PROPERTY(
+    QString status
+    READ getStatus
+    NOTIFY statusChanged
+  )
+
+  /**
+   *  @brief TF status message
+   */
+  Q_PROPERTY(
+    QString message
+    READ getMessage
+    NOTIFY messageChanged
+  )
+
+  /**
+   *  @brief TF status color
+   */
+  Q_PROPERTY(
+    QString color
+    READ getColor
+    NOTIFY colorChanged
+  )
+
+public:
+  // Constructor
+  TFStatus();
+
+  // Destructor
+  ~TFStatus() {}
+
+  /**
+   * @brief Update tf status and message
+   * @param[in] _fixedFrame FixedFrame name
+   * @param[in] _allFrames List of all frames
+   * @return True if status has changed else false
+   */
+  bool update(std::string & _fixedFrame, std::vector<std::string> & _allFrames);
+
+  /**
+   * @brief Get the TF status as a string
+   * @return TF status
+   */
+  Q_INVOKABLE QString getStatus() const;
+
+  /**
+   * @brief Get the TF status message as a string
+   * @return TF status message
+   */
+  Q_INVOKABLE QString getMessage() const;
+
+  /**
+   * @brief Get the TF status color as a string
+   * @return TF status color
+   */
+  Q_INVOKABLE QString getColor() const;
+
+signals:
+  /**
+   * @brief Notify that TF status has changed
+   */
+  void statusChanged();
+
+signals:
+  /**
+   * @brief Notify that TF message has changed
+   */
+  void messageChanged();
+
+signals:
+  /**
+   * @brief Notify that TF color has changed
+   */
+  void colorChanged();
+
+private:
+  QString status;
+  QString message;
+  QString color;
+  int currentState;
+};
+
 /**
  * @brief Configure global option of ignition rviz
  *
@@ -60,27 +155,9 @@ class GlobalOptions : public MessageDisplayBase
    *  @brief TF status
    */
   Q_PROPERTY(
-    QString tfStatus
+    TFStatus * tfStatus
     READ getTfStatus
     NOTIFY tfStatusChanged
-  )
-
-  /**
-   *  @brief TF status message
-   */
-  Q_PROPERTY(
-    QString tfStatusMessage
-    READ getTfStatusMessage
-    NOTIFY tfStatusMessageChanged
-  )
-
-  /**
-   *  @brief TF status color
-   */
-  Q_PROPERTY(
-    QString tfStatusColor
-    READ getTfStatusColor
-    NOTIFY tfStatusColorChanged
   )
 
 public:
@@ -95,11 +172,6 @@ public:
 
   // Documentation Inherited
   void setFrameManager(std::shared_ptr<common::FrameManager> _frameManager) override;
-
-  /**
-   * @brief Update tf status and message
-   */
-  void updateTfStatus();
 
   /**
    * @brief Qt eventFilters. Original documentation can be found
@@ -126,28 +198,16 @@ public:
   Q_INVOKABLE QStringList getFrameList() const;
 
   /**
+   * @brief Get the TF status as a TFStatus object
+   * @return TFStatus object
+   */
+  Q_INVOKABLE TFStatus * getTfStatus() const;
+
+  /**
    * @brief Set the frame list from a string
    * @param[in] _frameList List of frames
    */
   Q_INVOKABLE void setFrameList(const QStringList & _frameList);
-
-  /**
-   * @brief Get the tf status as a string
-   * @return Tf status
-   */
-  Q_INVOKABLE QString getTfStatus() const;
-
-  /**
-   * @brief Get the tf status message as a string
-   * @return Tf status message
-   */
-  Q_INVOKABLE QString getTfStatusMessage() const;
-
-  /**
-   * @brief Get the tf status color as a string
-   * @return Tf status color
-   */
-  Q_INVOKABLE QString getTfStatusColor() const;
 
 signals:
   /**
@@ -157,28 +217,16 @@ signals:
 
 signals:
   /**
-   * @brief Set combo box index
-   * @param index Combo box index
-   */
-  void setCurrentIndex(const int index);
-
-signals:
-  /**
-   * @brief Notify that tf status has changed
+   * @brief Notify that TF status has changed
    */
   void tfStatusChanged();
 
 signals:
   /**
-   * @brief Notify that tf status message has changed
+   * @brief Set combo box index
+   * @param index Combo box index
    */
-  void tfStatusMessageChanged();
-
-signals:
-  /**
-   * @brief Notify that tf status message has changed
-   */
-  void tfStatusColorChanged();
+  void setCurrentIndex(const int index);
 
 public slots:
   /**
@@ -195,9 +243,7 @@ private:
   bool initialized;
   bool populated;
   QColor color;
-  QString tfStatus;
-  QString tfStatusMessage;
-  QString tfStatusColor;
+  TFStatus * tfStatus;
 };
 
 }  // namespace plugins

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
@@ -56,6 +56,33 @@ class GlobalOptions : public MessageDisplayBase
     NOTIFY frameListChanged
   )
 
+  /**
+   *  @brief TF status
+   */
+  Q_PROPERTY(
+    QString tfStatus
+    READ getTfStatus
+    NOTIFY tfStatusChanged
+  )
+
+  /**
+   *  @brief TF status message
+   */
+  Q_PROPERTY(
+    QString tfStatusMessage
+    READ getTfStatusMessage
+    NOTIFY tfStatusMessageChanged
+  )
+
+  /**
+   *  @brief TF status color
+   */
+  Q_PROPERTY(
+    QString tfStatusColor
+    READ getTfStatusColor
+    NOTIFY tfStatusColorChanged
+  )
+
 public:
   // Constructor
   GlobalOptions();
@@ -68,6 +95,11 @@ public:
 
   // Documentation Inherited
   void setFrameManager(std::shared_ptr<common::FrameManager> _frameManager) override;
+
+  /**
+   * @brief Update tf status and message
+   */
+  void updateTfStatus();
 
   /**
    * @brief Qt eventFilters. Original documentation can be found
@@ -99,6 +131,24 @@ public:
    */
   Q_INVOKABLE void setFrameList(const QStringList & _frameList);
 
+  /**
+   * @brief Get the tf status as a string
+   * @return Tf status
+   */
+  Q_INVOKABLE QString getTfStatus() const;
+
+  /**
+   * @brief Get the tf status message as a string
+   * @return Tf status message
+   */
+  Q_INVOKABLE QString getTfStatusMessage() const;
+
+  /**
+   * @brief Get the tf status color as a string
+   * @return Tf status color
+   */
+  Q_INVOKABLE QString getTfStatusColor() const;
+
 signals:
   /**
    * @brief Notify that frame list has changed
@@ -111,6 +161,24 @@ signals:
    * @param index Combo box index
    */
   void setCurrentIndex(const int index);
+
+signals:
+  /**
+   * @brief Notify that tf status has changed
+   */
+  void tfStatusChanged();
+
+signals:
+  /**
+   * @brief Notify that tf status message has changed
+   */
+  void tfStatusMessageChanged();
+
+signals:
+  /**
+   * @brief Notify that tf status message has changed
+   */
+  void tfStatusColorChanged();
 
 public slots:
   /**
@@ -127,6 +195,9 @@ private:
   bool initialized;
   bool populated;
   QColor color;
+  QString tfStatus;
+  QString tfStatusMessage;
+  QString tfStatusColor;
 };
 
 }  // namespace plugins

--- a/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
+++ b/ign_rviz_plugins/include/ignition/rviz/plugins/GlobalOptions.hpp
@@ -24,9 +24,9 @@
 #include <ignition/math/Color.hh>
 #include <QColor>
 #include <string>
-#include <vector>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "ignition/rviz/plugins/message_display_base.hpp"
 
@@ -85,9 +85,8 @@ public:
    * @brief Update tf status and message
    * @param[in] _fixedFrame FixedFrame name
    * @param[in] _allFrames List of all frames
-   * @return True if status has changed else false
    */
-  bool update(std::string & _fixedFrame, std::vector<std::string> & _allFrames);
+  void update(std::string & _fixedFrame, std::vector<std::string> & _allFrames);
 
   /**
    * @brief Get the TF status as a string
@@ -129,7 +128,6 @@ private:
   QString status;
   QString message;
   QString color;
-  int currentState;
 };
 
 /**

--- a/ign_rviz_plugins/res/qml/GlobalOptions.qml
+++ b/ign_rviz_plugins/res/qml/GlobalOptions.qml
@@ -113,12 +113,16 @@ Item {
         id: "status"
         text: GlobalOptions.tfStatus.status
         color: GlobalOptions.tfStatus.color
+        font.pointSize: 11
       }
 
       Label {
         id: "message"
         text: GlobalOptions.tfStatus.message
         color: GlobalOptions.tfStatus.color
+        font.pointSize: 11
+        Layout.fillWidth: true
+        elide: Label.ElideRight
       }
     }
   }

--- a/ign_rviz_plugins/res/qml/GlobalOptions.qml
+++ b/ign_rviz_plugins/res/qml/GlobalOptions.qml
@@ -22,7 +22,7 @@ import QtQuick.Dialogs 1.0
 
 Item {
   Layout.minimumWidth: 280
-  Layout.minimumHeight: 200
+  Layout.minimumHeight: 220
   anchors.fill: parent
   anchors.margins: 10
 
@@ -102,6 +102,23 @@ Item {
           bgColor.color = text
           GlobalOptions.setSceneBackground(text);
         }
+      }
+    }
+
+    RowLayout {
+      width: parent.width
+      spacing: 10
+
+      Label {
+        id: "tfStatus"
+        text: GlobalOptions.tfStatus
+        color: GlobalOptions.tfStatusColor
+      }
+
+      Label {
+        id: "tfStatusMessage"
+        text: GlobalOptions.tfStatusMessage
+        color: GlobalOptions.tfStatusColor
       }
     }
   }

--- a/ign_rviz_plugins/res/qml/GlobalOptions.qml
+++ b/ign_rviz_plugins/res/qml/GlobalOptions.qml
@@ -110,15 +110,15 @@ Item {
       spacing: 10
 
       Label {
-        id: "tfStatus"
-        text: GlobalOptions.tfStatus
-        color: GlobalOptions.tfStatusColor
+        id: "status"
+        text: GlobalOptions.tfStatus.status
+        color: GlobalOptions.tfStatus.color
       }
 
       Label {
-        id: "tfStatusMessage"
-        text: GlobalOptions.tfStatusMessage
-        color: GlobalOptions.tfStatusColor
+        id: "message"
+        text: GlobalOptions.tfStatus.message
+        color: GlobalOptions.tfStatus.color
       }
     }
   }

--- a/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
@@ -33,48 +33,34 @@ namespace plugins
 {
 ////////////////////////////////////////////////////////////////////////////////
 TFStatus::TFStatus()
-: status(" "), message(" "), color("green"), currentState(0)
+: status(" "), message(" "), color("green")
 {}
 
 ////////////////////////////////////////////////////////////////////////////////
-bool TFStatus::update(std::string & _fixedFrame, std::vector<std::string> & _allFrames)
+void TFStatus::update(std::string & _fixedFrame, std::vector<std::string> & _allFrames)
 {
   // Check for tf data
   auto framePosition = std::find(_allFrames.begin(), _allFrames.end(), _fixedFrame);
 
-  if (!_allFrames.size()) {
+  if (_allFrames.empty()) {
     std::string msg = "No tf data. Frame [" + _fixedFrame + "] does not exist";
 
     this->status = QString::fromStdString("Fixed Frame [Warn]");
     this->message = QString::fromStdString(msg);
     this->color = QString::fromStdString("orange");
-    if (currentState != 1) {
-      currentState = 1;
-      return true;
-    }
   } else if (framePosition == _allFrames.end()) {
     std::string msg = "Frame [" + _fixedFrame + "] does not exist";
 
     this->status = QString::fromStdString("Fixed Frame [Error]");
     this->message = QString::fromStdString(msg);
     this->color = QString::fromStdString("red");
-
-    if (currentState != 2) {
-      currentState = 2;
-      return true;
-    }
   } else {
     std::string msg = "OK";
 
     this->status = QString::fromStdString("Fixed Frame");
     this->message = QString::fromStdString(msg);
     this->color = QString::fromStdString("green");
-    if (currentState != 3) {
-      currentState = 3;
-      return true;
-    }
   }
-  return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -166,9 +152,8 @@ bool GlobalOptions::eventFilter(QObject * _object, QEvent * _event)
     std::vector<std::string> allFrames;
     this->frameManager->getFrames(allFrames);
     std::string fixedFrame = this->frameManager->getFixedFrame();
-    if (this->tfStatus->update(fixedFrame, allFrames)) {
-      emit tfStatusChanged();
-    }
+    this->tfStatus->update(fixedFrame, allFrames);
+    emit tfStatusChanged();
   }
 
   // Update combo-box on frame list change

--- a/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
+++ b/ign_rviz_plugins/src/rviz/plugins/GlobalOptions.cpp
@@ -166,7 +166,6 @@ bool GlobalOptions::eventFilter(QObject * _object, QEvent * _event)
     std::vector<std::string> allFrames;
     this->frameManager->getFrames(allFrames);
     std::string fixedFrame = this->frameManager->getFixedFrame();
-    
     if (this->tfStatus->update(fixedFrame, allFrames)) {
       emit tfStatusChanged();
     }


### PR DESCRIPTION
Reference to issue #68 

- Added `FixedFrame` tf status.

- Screenshots:

  a. TF warn
  ![Screenshot from 2020-11-29 14-16-06](https://user-images.githubusercontent.com/39728574/100541192-1aa5e780-3268-11eb-9113-4d221dd0aeb6.png)
  b. TF error
  ![Screenshot from 2020-11-29 14-16-58](https://user-images.githubusercontent.com/39728574/100541215-3f9a5a80-3268-11eb-9890-fe01a9863bf6.png)
  c. Valid frame
  ![Screenshot from 2020-11-29 14-17-36](https://user-images.githubusercontent.com/39728574/100541226-58a30b80-3268-11eb-9ca1-ab738772bc5d.png)
